### PR TITLE
WOOOOOO

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -10,6 +10,8 @@ const Upvote = require('./Structures/Upvote');
 const User = require('./Structures/User');
 const Pagination = require('./Structures/Pagination');
 
+const isObject = (obj) => !Array.isArray(obj) && obj === Object(obj);
+
 /**
  * Creates a new client.
  * @class Client
@@ -18,14 +20,14 @@ class Client {
 	/**
 	 * @param {object} options An object with client options.
 	 * @param {string} options.id The ID of the server.
-	 * @param {string} options.userToken The token provided from the user's token page.
+	 * @param {string} [options.userToken] The token provided from the user's token page.
 	 * @param {string} options.serverToken The token provided from the server's token page.
 	 */
 	constructor(options) {
-		if (!(options instanceof Object)) throw new TypeError('Options must be an object');
-		if (!(options.id instanceof String)) throw new TypeError('ID in options object must be a string');
-		if ('userToken' in options && !(options.userToken instanceof String)) throw new TypeError('User token in options object must be a string');
-		if (!(options.serverToken instanceof String)) throw new TypeError('Server token in options object must be a string');
+		if (!isObject(options)) throw new TypeError('Options must be an object');
+		if (typeof options.id !== 'string') throw new TypeError('ID in options object must be a string');
+		if ('userToken' in options && typeof options.userToken !== 'string') throw new TypeError('User token in options object must be a string');
+		if (typeof options.serverToken !== 'string') throw new TypeError('Server token in options object must be a string');
 
 		this._baseURL = 'https://api.serverlist.space/v1';
 		this._options = options;
@@ -56,7 +58,7 @@ class Client {
 	 * @returns {Promise<Pagination|HTTPError>}
 	 */
 	getAllServers(page = 1) {
-		if (!(page instanceof Number)) throw new TypeError('Page must be a number');
+		if (typeof page !== 'number') throw new TypeError('Page must be a number');
 		if (page < 1) throw new SyntaxError('Page must be a number greater than 0.');
 		return new Promise((resolve, reject) => {
 			snekfetch
@@ -84,7 +86,7 @@ class Client {
 	 * @param {string} id The ID of the server you want to get information on.
 	 */
 	getServer(id) {
-		if (!(id instanceof String)) throw new TypeError('ID must be a string');
+		if (typeof id !== 'string') throw new TypeError('ID must be a string');
 		return new Promise((resolve, reject) => {
 			snekfetch
 				.get(this._baseURL + '/servers/' + id)
@@ -104,6 +106,8 @@ class Client {
 	 * @param {number} [page=1] The page number.
 	 */
 	getUpvotes(page = 1) {
+		if (typeof page !== 'number') throw new TypeError('Page must be a number');
+		if (page < 1) throw new SyntaxError('Page must be a number greater than 0.');
 		return new Promise((resolve, reject) => {
 			snekfetch
 				.get(this._baseURL + '/servers/' + this._id + '/upvotes')
@@ -131,7 +135,7 @@ class Client {
 	 * @returns {Promise<boolean|HTTPError>}
 	 */
 	hasUpvoted(userID) {
-		if (!(userID instanceof String)) throw new TypeError('User ID must be a string');
+		if (typeof userID !== 'string') throw new TypeError('User ID must be a string');
 		return new Promise((resolve, reject) => {
 			this
 				.getUpvotes()
@@ -160,7 +164,7 @@ class Client {
 	 * @param {string} id The ID of the user you want to get information on.
 	 */
 	getUser(id) {
-		if (!(id instanceof String)) throw new TypeError('User ID is not a string');
+		if (typeof id !== 'string') throw new TypeError('User ID is not a string');
 		return new Promise((resolve, reject) => {
 			snekfetch
 				.get(this._baseURL + '/users/' + id)
@@ -181,8 +185,8 @@ class Client {
 	 * @param {number} [page=1] The page number.
 	 */
 	getUserServers(id, page = 1) {
-		if (!(id instanceof String)) throw new TypeError('User ID is not a string');
-		if (!(page instanceof Number)) throw new TypeError('Page must be a number');
+		if (typeof id !== 'string') throw new TypeError('User ID is not a string');
+		if (typeof page !== 'number') throw new TypeError('Page must be a number');
 		if (page < 1) throw new SyntaxError('Page must be a number greater than 0.');
 		return new Promise((resolve, reject) => {
 			snekfetch

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -3,6 +3,8 @@ const EventEmitter = require('events').EventEmitter;
 
 const User = require('./Structures/User');
 
+const isObject = (obj) => !Array.isArray(obj) && obj === Object(obj);
+
 /**
  * Creates a new gateway client.
  * @extends EventEmitter
@@ -18,11 +20,11 @@ class WebSocket extends EventEmitter {
 	constructor(options) {
 		super();
 
-		if (!(options instanceof Object)) throw new TypeError('Options must be an object');
-		if (!(options.tokens instanceof Array) || !options.tokens.every((token) => typeof token === 'string')) throw new TypeError('\'tokens\' must be an array of strings');
-		if ('heartbeatInterval' in options && !(options.tokens instanceof Number)) throw new TypeError('\'heartbeatInterval\' must be a number when provided');
+		if (!isObject(options)) throw new TypeError('Options must be an object');
+		if (!Array.isArray(options.tokens) || !options.tokens.some((token) => typeof token !== 'string')) throw new TypeError('\'tokens\' must be an array of strings');
+		if ('heartbeatInterval' in options && typeof options.heartbeatInterval !== 'number') throw new TypeError('\'heartbeatInterval\' must be a number when provided');
 		if ('heartbeatInterval' in options && options.heartbeatInterval > 55) throw new TypeError('\'heartbeatInterval\' must be less than or equal to 55');
-		if ('reconnect' in options && !(options.reconnect instanceof Boolean)) throw new TypeError('\'reconnect\' must be a boolean when provided');
+		if ('reconnect' in options && typeof options.reconnect !== 'boolean') throw new TypeError('\'reconnect\' must be a boolean when provided');
 
 		this._socket = new ws('wss://gateway.serverlist.space');
 


### PR DESCRIPTION
# Pull Request Stuff

**Pull Request Info:** When users use functions with parameters, instead of using `Something instanceof Constructor`, use the `typeof Something === 'type'` in place.

**Improves Usability How:** `'str' instanceof String` is false, `0 instanceof Number` is false. `typeof str === 'string'` is true, and `typeof 0 === 'number'` is true.

**Reasoning:** User's convenience so they don't have to run `new String('str')` for every string-type parameter, same for number.

- [x] Includes changing Library Code
    - [ ] Minor Changes (Var Changes, Method Renames, Property Renames)
    - [x] Major Changes (Method Renames, Structure Renames, Property to Method, Method to Property, New Functions)
- [ ] Includes changing README.md file
    - [ ] Minor Changes (Typo, Title Rename, Word Replacement)
    - [ ] Major Changes (Everything Else)